### PR TITLE
400 catch + style prompt

### DIFF
--- a/backend/src/services/tts/tts_test.py
+++ b/backend/src/services/tts/tts_test.py
@@ -16,10 +16,11 @@ if not api_key:
 client = genai.Client(api_key=api_key)
 
 def text_to_wav(text: str):
+    style_prompt = f"Read the following in a friendly and professional tone: {text}"
     try:
         response = client.models.generate_content(  #Calls Gemini
             model = "gemini-2.5-flash-preview-tts",
-            contents=text,
+            contents=style_prompt,
             config=types.GenerateContentConfig(
                 response_modalities = ["AUDIO"],
                 speech_config=types.SpeechConfig(
@@ -31,7 +32,7 @@ def text_to_wav(text: str):
                 )
             ),
         )
-    except ClientError as e:
+    except ClientError as e:  #Checks if Gemini accepted text
         if e.code == 400:
             print(f"Gemini TTS rejected the input text: {text!r}")
             return None


### PR DESCRIPTION
## Summary

### What changed

- Added a style prompt, instructing the model to be friendly and professional.
- Added a catch for 400 errors, in case Gemini rejects any text
- Trimmed the testing menu down to the custom text input.

### Why it changed

- I was running into an issue where Gemini would throw a 400 error for very short strings of text (three words or less). It turns out this can occur when Gemini does not have enough context to determine tone. Adding a style prompt fixes this. I've also added a 400 error check just in case a 400 error occurs despite that.

---

## Testing

### How to test

- Run the tts_test.py file and enter a very short phrase. If you try entering a phrase of 3 words or less into tts_test.py main branch, it will sometimes return a 400 error, but when entering the same phrases on this branch, that should not occur.

### Test status

- [ ] Tested locally
- [ ] Tests added or updated
- [ ] Not applicable (explain why)

---

## Documentation

- [ ] README updated (root or relevant subproject)
- [ ] Inline code comments added where necessary
- [ ] No documentation changes needed (explain why)

---

## Impact

### Breaking changes

- [ ] No breaking changes
- [ ] Yes (describe impact and migration steps)

### Affected components

- Backend

---

## Checklist

- [ ] Code builds and runs locally
- [ ] Follows project structure and conventions
- [ ] No unrelated files included
- [ ] PR title is clear and descriptive
