### PR TITLE
Minor update: Modified print syntax to better match frontend needs

### DIFF
--- a/backend/src/services/tts/tts_test.py
+++ b/backend/src/services/tts/tts_test.py
@@ -63,8 +63,6 @@ def text_to_wav(text: str):
 
     speak_wav("output.wav")
 
-    print(f"Audio saved to output.wav")
-
 def speak_wav(file: str):
     pygame.mixer.music.load(file)
     pygame.mixer.music.play()

--- a/backend/src/services/tts/tts_wrapper.py
+++ b/backend/src/services/tts/tts_wrapper.py
@@ -24,10 +24,9 @@ def run_tts_service(get_text_callback, poll_interval=0.5):
             text = get_text_callback()
 
             if text:
+                print(f"TTS_SPEECH_STARTED", flush=True)
                 print(f"\nSpeaking: {text!r}")
                 tts_test.text_to_wav(text)
-            else:
-                print(".", end="", flush=True)  #'.' to show activity
 
             time.sleep(poll_interval)  #Waits before getting more text
 


### PR DESCRIPTION
## Adds flag for frontend, and minor print changes

### What changed

- A print statement: TTS_SPEECH_STARTED was added to the wrapper to display each time before the text to speech functions are called.
- The idle print statement ".", previously used to confirm the TTS wrapper is still receiving were removed.
- The print statement "Audio saved to output.wav" has been removed.

### Why it changed

- The TTS_SPEECH_STARTED was added at Satvik's request. I understand he will be using it as a flag for the frontend's animation.
- The idle "." was previously used to verify that the wrapper was still listening. I have encountered no issues with this, so I am removing the "." to avoid clutter.
- The "Audio saved to output.wav" statement is also useless clutter, as output.wav is unused after the statement, and I expect it to remain unused.

---

## Testing

### How to test

- The only changes are to print statements, so running tts_wrapper.py and tts_test.py should be sufficient to observe the changes.

### Test status

- [ ] Tested locally
- [ ] Tests added or updated
- [ ] Not applicable (explain why)

---

## Documentation

- [ ] README updated (root or relevant subproject)
- [ ] Inline code comments added where necessary
- [ ] No documentation changes needed (explain why)

---

## Impact

### Breaking changes

- [ ] No breaking changes
- [ ] Yes (describe impact and migration steps)

### Affected components

- Backend

---

## Checklist

- [ ] Code builds and runs locally
- [ ] Follows project structure and conventions
- [ ] No unrelated files included
- [ ] PR title is clear and descriptive
