### PR TITLE
commented out now-unneeded instruction in run function of fishbowl.sh

### DIFF
--- a/fishbowl.sh
+++ b/fishbowl.sh
@@ -76,7 +76,7 @@ run() {
 		exit 1
 	fi
 	source "$VENV/bin/activate"
-	(cd "$ROOT/backend/src/mcp_stack" && fastapi dev client.py)
+	#(cd "$ROOT/backend/src/mcp_stack" && fastapi dev client.py)
 	(cd "$ROOT/frontend/electron" && npm start)
 }
 


### PR DESCRIPTION
## Summary
Removed the `fastapi dev client.py` line from the run function since it is no longer part of the steps to run the app.

### What changed

- commented-out one line from `fishbowl.sh`

### Why it changed

- proper running of program using `fishbowl.sh` script

---

## Testing

### How to test

- run `./fishbowl.sh setup` (only needed once) then `./fishbowl.sh run` to run the program

### Test status

- [x] Tested locally
- [ ] Tests added or updated
- [ ] Not applicable (explain why)

---

## Documentation

- [ ] README updated (root or relevant subproject)
- [ ] Inline code comments added where necessary
- [x] No documentation changes needed (explain why)
(no changes in documentation since functionality is unchanged)

---

## Impact

### Breaking changes

- [x] No breaking changes
- [ ] Yes (describe impact and migration steps)

### Affected components

- Backend
- Frontend
- Hardware
- MCP tools
- Documentation

---

## Checklist

- [x] Code builds and runs locally
- [x] Follows project structure and conventions
- [x] No unrelated files included
- [x] PR title is clear and descriptive
