### PR TITLE
Added tts time limit, re-submitted tts_test.py

### DIFF
--- a/backend/src/services/tts/README.md
+++ b/backend/src/services/tts/README.md
@@ -34,7 +34,7 @@ The following dependencies are required:
 - `pyaudio`
 - `pathlib`
 - `websockets`
-- `asyncio`
+- `asyncio` (For tts_test only)
 
 ## Important Note
 

--- a/backend/src/services/tts/tts_functions.py
+++ b/backend/src/services/tts/tts_functions.py
@@ -12,6 +12,12 @@ CHANNELS = 1
 FORMAT = pyaudio.paInt16
 CHUNK = 2048  #This buffer could be lowered for faster speed, but too low produces audio fuzz
 
+MAX_TIME = 90 #max speaking time in seconds (this includes tts processing time)
+BYTES_PER_SECOND = RATE * CHANNELS * 2
+
+#The maximum number of bytes to write based on max seconds
+MAX_BYTES = MAX_TIME * BYTES_PER_SECOND
+
 api_key = os.getenv("KEY")   #Gets API key from .env file
 if not api_key:
     raise RuntimeError("KEY not found")
@@ -53,12 +59,23 @@ def speak_text(text: str):
             raise
 
     print("Streaming audio...")
-    
+
+    written_bytes = 0  #How many bytes have been sent to the speaker
+
     for chunk in response:
         for part in getattr(chunk, "parts", []):
             if hasattr(part, "inline_data") and part.inline_data:
                 audio_bytes = part.inline_data.data
+
+                remaining = MAX_BYTES - written_bytes #Checks if number of bytes exceeds time limit (based on bytes per second)
+                if remaining <= 0:
+                    print("Exceeded time limit")
+                    return
+
+                audio_bytes = audio_bytes[:remaining]
+
                 stream.write(audio_bytes)
+                written_bytes += len(audio_bytes)
 
     print("Done Speaking")
 

--- a/backend/src/services/tts/tts_test.py
+++ b/backend/src/services/tts/tts_test.py
@@ -1,83 +1,31 @@
-import os
-import wave
-os.environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "1" #Stops a default pygame support prompt from appearing
-import pygame
-import google.genai as genai
-from google.genai import types
-from google.genai.errors import ClientError
-from dotenv import load_dotenv
+import tts_functions
+import pathlib
+import asyncio
 
-load_dotenv()
-
-pygame.mixer.init()
-
-api_key = os.getenv("KEY")   #Gets API key from .env file
-if not api_key:
-    raise RuntimeError("KEY not found")
-
-client = genai.Client(api_key=api_key)
-
-def text_to_wav(text: str):
-    style_prompt = f"Read the following in a friendly and professional tone: {text}"
-    try:
-        response = client.models.generate_content(  #Calls Gemini
-            model = "gemini-2.5-flash-preview-tts",
-            contents=style_prompt,
-            config=types.GenerateContentConfig(
-                response_modalities = ["AUDIO"],
-                speech_config=types.SpeechConfig(
-                    voice_config=types.VoiceConfig(
-                        prebuilt_voice_config = types.PrebuiltVoiceConfig(  #Calls one of Gemini's default voices
-                            voice_name="Umbriel"
-                        )
-                    )
-                )
-            ),
-        )
-    except ClientError as e:  #Checks if Gemini accepted text
-        if e.code == 400:
-            print(f"Gemini TTS rejected the input text: {text!r}")
-            return None
-        else:
-            raise
-
-    if not hasattr(response, "parts") or response.parts is None:
-        print("No Gemini response")
-        return None
-
-    audio_bytes = None
-    for part in response.parts:   #Extracts audio bytes from Gemini response
-        if hasattr(part, "inline_data") and part.inline_data:
-            audio_bytes = part.inline_data.data
+async def main():
+    print("Listening for input in incoming.txt... (Ctrl+C to stop)")
+    
+    while True:
+        try:
+            p = pathlib.Path("incoming.txt")
+            if not p.exists():
+                p.write_text("")
+            
+            raw = p.read_text()
+            if raw:
+                text = raw.strip()
+                p.write_text("")
+                tts_functions.speak_text(text)
+            
+            await asyncio.sleep(0.5)
+        
+        except KeyboardInterrupt:
+            print("\nTest stopped")
             break
 
-    if not audio_bytes:
-        print("No audio data found in response")
-        return None
-
-    with wave.open("output.wav", "wb") as wf:  #Stores Gemini's PCM output to a .wav file
-        wf.setnchannels(1)
-        wf.setsampwidth(2)
-        wf.setframerate(24000) 
-        wf.writeframes(audio_bytes)
-
-    speak_wav("output.wav")
-
-    #print(f"Audio saved to output.wav")
-
-def speak_wav(file: str):
-    pygame.mixer.music.load(file)
-    pygame.mixer.music.play()
-
-    while pygame.mixer.music.get_busy():
-        pygame.time.Clock().tick(30)
-
-    pygame.mixer.music.unload()
+        except Exception as e:
+            print(f"Error: {e}")
+            await asyncio.sleep(1)
 
 if __name__ == "__main__":
-    text = input("Enter text: ")
-
-    if text:
-        play_obj = text_to_wav(text)
-
-    print("Test complete!")
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

### What changed

- Added a maximum time limit for text to speech processing of 90 seconds in tts_functions.py based on bytes per second. After this time limit is reached, the audio cuts off. It should be noted, the time limit is based on bytes streamed and bytes streamed per second, so the count begins when Gemini starts speaking, not when it starts processing.
- Re-submitted the proper tts_test.py.

### Why it changed

- The time limit was added as a fail safe to avoid the TTS wasting credits by speaking for absurdly long periods of time (like if it is told to count to one million).
- The tts_test.py seems to have been over looked during a previous inter-branch merger. The version currently on main is outdated and not a usable test file. This branch restores tts_test.py for easy testing.

---

## Testing

### How to test

- The best way to test this is by running tts_test.py, and copy-and-pasting a long text document into it to guarantee that the text-to-speech attempts to speak for longer than 90 seconds.

### Test status

- [ ] Tested locally
- [ ] Tests added or updated
- [ ] Not applicable (explain why)

---

## Documentation

- [ ] README updated (root or relevant subproject)
- [ ] Inline code comments added where necessary
- [ ] No documentation changes needed (explain why)

---

## Impact

### Breaking changes

- [ ] No breaking changes
- [ ] Yes (describe impact and migration steps)

### Affected components

- Backend
- Frontend
- Hardware
- MCP tools
- Documentation

---

## Checklist

- [ ] Code builds and runs locally
- [ ] Follows project structure and conventions
- [ ] No unrelated files included
- [ ] PR title is clear and descriptive
