### PR TITLE
Modified tts time limit

### DIFF
--- a/backend/src/services/tts/tts_functions.py
+++ b/backend/src/services/tts/tts_functions.py
@@ -27,6 +27,7 @@ stream = p.open(
     format=FORMAT,
     channels=CHANNELS,
     rate=RATE,
+    output=True,
     frames_per_buffer=FRAME_LENGTH,
 )
 

--- a/backend/src/services/tts/tts_test.py
+++ b/backend/src/services/tts/tts_test.py
@@ -18,14 +18,13 @@ async def main():
                 tts_functions.speak_text(text)
             
             await asyncio.sleep(0.5)
-        
-        except KeyboardInterrupt:
-            print("\nTest stopped")
-            break
 
         except Exception as e:
             print(f"Error: {e}")
             await asyncio.sleep(1)
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("\nTest stopped")


### PR DESCRIPTION
## Summary

### What changed

- The TTS time limit is now based on time (including processing time) rather than bits. This was done by slicing the audio chunks received by Gemini, so the time could be checked as frequently as needed
- EDIT: Updated Feb. 12, the line "output=True" was erroneously removed when the original pull request was submitted, causing the tts always run properly. This has now been re-added.
- tts_test.py was updated to cleanly exit on Ctrl+C without displaying an error.

### Why it changed

- To create stricter max time limits that account for processing time.

---

## Testing

### How to test

- I'd recommend copy-and-pasting a long string of text in to instructions.txt and running tts_test.py. It should be long enough to hit the max time of 90 seconds.
- EDIT: If testing was performed before Feb. 12th, try testing it again, the error in the original pull request has now been fixed.

### Test status

- [ ] Tested locally
- [ ] Tests added or updated
- [ ] Not applicable (explain why)

---

## Documentation

- [ ] README updated (root or relevant subproject)
- [ ] Inline code comments added where necessary
- [ ] No documentation changes needed (explain why)

---

## Impact

### Breaking changes

- [ ] No breaking changes
- [ ] Yes (describe impact and migration steps)

### Affected components

- Backend
- Frontend
- Hardware
- MCP tools
- Documentation

---

## Checklist

- [ ] Code builds and runs locally
- [ ] Follows project structure and conventions
- [ ] No unrelated files included
- [ ] PR title is clear and descriptive
